### PR TITLE
Require rake

### DIFF
--- a/lib/rails_stats.rb
+++ b/lib/rails_stats.rb
@@ -4,5 +4,6 @@ module RailsStats
 
 end
 
+require 'rake'
 require 'rails_stats/tasks'
 


### PR DESCRIPTION
This addresses a gem load error, if rake isn't loaded before.

Closes #6.